### PR TITLE
Make `ssc_sim` backward compatible with v1.2

### DIFF
--- a/files/PySSC.py
+++ b/files/PySSC.py
@@ -267,7 +267,7 @@ def ssc_sim(data_ssc, tech_model_name, financial_model_name):
         tech_model_dict["cmod_success"] = 0
         return tech_model_dict
 
-    if financial_model_name is None:
+    if financial_model_name in [None, "none"]:
         tech_model_dict["cmod_success"] = 1
         return tech_model_dict
 


### PR DESCRIPTION
@dguittet I should have thought of this when I suggested changing from "none" to None for `financial_model_name`.  A suggested way to keep the function backward compatible.