### PR TITLE
UTC Timezone issues with ResourceTools

### DIFF
--- a/files/ResourceTools.py
+++ b/files/ResourceTools.py
@@ -367,7 +367,7 @@ class FetchResourceFiles():
 
             # --- Find url for closest point ---
             lookup_base_url = 'https://developer.nrel.gov/api/solar/'
-            lookup_query_url = "nsrdb_data_query.json?api_key={}&wkt=POINT({}+{})".format(self.nrel_api_key, lon, lat)
+            lookup_query_url = "nsrdb_data_query.json?api_key={}&wkt=POINT({}+{})&utc=false".format(self.nrel_api_key, lon, lat)
             lookup_url = lookup_base_url + lookup_query_url
             lookup_response = retry_session.get(lookup_url)
 


### PR DESCRIPTION
When fetching files from the NSRDB using `PySAM.ResourceTools.FetchResourceFiles(tech='pv')`, the returned csv file lists the time zone = 0, or in UTC time. According to the [NSRDB API documentation](https://nsrdb.nrel.gov/data-sets/api-instructions.html), it states that the `utc` parameter in the API call must be set to false:
```
# Specify Coordinated Universal Time (UTC), 'true' will use UTC, 'false' will use the local time zone of the data.
  # NOTE: In order to use the NSRDB data in SAM, you must specify UTC as 'false'. SAM requires the data to be in the
  # local time zone.
```
However, in the `_NSRDB_worker` function in `ResourceTools` the `lookup_query_url` variable does not include the `&utc=false` parameter
