### PR TITLE
add all supported units to URDB conversion function in ResourceTools

### DIFF
--- a/files/ResourceTools.py
+++ b/files/ResourceTools.py
@@ -129,6 +129,12 @@ def URDBv7_to_ElectricityRates(urdb_response):
 
     def try_get_rate_structure(urdb_name, data_name):
         mat = []
+        supported_units = {
+            "kwh" : 0,
+            "kwh/kw" : 1,
+            "kwh daily" : 2,
+            "kwh/kw daily" : 3
+        }
         if urdb_name in urdb_response.keys():
             structure = urdb_response[urdb_name]
             for i, period in enumerate(structure):
@@ -142,10 +148,13 @@ def URDBv7_to_ElectricityRates(urdb_response):
                     sell = 0
                     if 'sell' in entry.keys():
                         sell = entry['sell']
+                    units = 0
                     if 'unit' in entry.keys():
-                        if entry['unit'].lower() != "kWh".lower():
+                        try:
+                            units = supported_units[entry['unit'].lower()]
+                        except KeyError:
                             raise RuntimeError("UtilityRateDatabase error: unrecognized unit in rate structure")
-                    mat.append((i + 1, j + 1, tier_max, 0.0, rate, sell))
+                    mat.append((i + 1, j + 1, tier_max, units, rate, sell))
             urdb_data[data_name] = mat
 
     def try_get_demand_structure(urdb_name, data_name):


### PR DESCRIPTION
Closes https://github.com/NREL/pysam/issues/70

Add all supported units from: https://github.com/NREL/SAM/blob/8e3245d31171482835ab9bd2c91fc1b16f1f82e0/src/urdb.cpp#L669 in URDB JSON to PySAM.Utilityrate5 converter.

kWh daily can be tested with rate https://openei.org/apps/IURDB/rate/view/5cbf66995457a3ce3d67107e

It might be easiest to test an invalid rate by altering Max Usage Units by hand. 

I haven't had a chance to test this due to issues building PySAM.Irradproc on Windows from branch pysam-v2.2.1, but am happy to help test once that's resolved.