### PR TITLE
Resolve changing coordinates when downloading multiple years of weather

### DIFF
--- a/files/ResourceTools.py
+++ b/files/ResourceTools.py
@@ -472,20 +472,15 @@ class FetchResourceFiles():
                 if len(outputs) < 1:
                     print('No URLS available for {}, {}.'.format(lat, lon))
                     return
-                names = [output['name'] for output in outputs]
-                links = [output['links'] for output in outputs]
                 ok = False
-                for items in links:
-                    for name in names:
-                        if self.resource_type == name:
-                            for link in links:
-                                for i in link:
-                                    if self.resource_year == str(i['year']) and self.resource_interval_min == i['interval']:
-                                        ok = True
-                                        data_url = i['link']
-                                        data_url = data_url.replace(
-                                            'yourapikey', self.nrel_api_key).replace(
-                                            'youremail', self.nrel_api_email+'&utc=false')
+                for output in outputs:
+                    if output['name'] == self.resource_type:
+                        for link in output['links']:
+                            if self.resource_year == str(link['year']) and self.resource_interval_min == link['interval']:
+                                ok = True
+                                data_url = link['link'].replace(
+                                    'yourapikey', self.nrel_api_key).replace(
+                                    'youremail', self.nrel_api_email) + '&utc=false'
 
                 # --- Get data ---
                 if ok:


### PR DESCRIPTION
When downloading weather data for single site I noticed that I was getting different PV results then with the datasets I had downloaded through the SAM GUI. After reviewing the changes between the two PV output files, the deltas were only for two years and upon inspection I discovered that for 1998-2017 I had data from one site and for 2018-2019 data from another. While the coordinates used were similar (a difference of 0.01 in Lat/Long), it is a show-stopping inconsistency.

I first reviewed the base URLs from the response JSON and saw that they were good. I then took a look at what URLs were being used to pull data and noticed that for 2018 and 2019 I was getting data from the psm3-5min dataset, while I had requested psm3. This was the source of the change.

I believe this bug was occurring because of the duplicate `for link in links` loop (there is already a `for items in links`, and I observed many possible data_urls be set before one was ever requested.

The changes I implemented seek to resolve this error. I reran my analysis and determined that the bug has been fixed, and I also validated that `test_resourcefilefetcher()` passes.

I would have preferred to use a for/else construct with each of the for loops I defined, but I elected not to in order to align with the existing error checking/messaging.