### PR TITLE
Fix unicode issue

### DIFF
--- a/src/PySAM_utils.h
+++ b/src/PySAM_utils.h
@@ -1143,9 +1143,7 @@ static PyObject* PySAM_run_getset(PyObject *self, PyObject *arg, PyObject * x_at
             getset++;
         }
     }
-    char str[256];
-    PySAM_concat_msg(str, "'value' error, could not find attribute: ", name);
-    PyErr_SetString(PyExc_AttributeError, str);
+    PyErr_SetString(PyExc_AttributeError, "\"value\" error, could not find attribute by that name");
     return NULL;
 }
 
@@ -1165,7 +1163,7 @@ static PyObject * Cmod_value(CmodObject *self, PyObject *args)
     PyObject* value = NULL;
     if (!PyArg_ParseTuple(args, "s|O", &name, &value))
 		return NULL;
-
+        
     return PySAM_run_getset((PyObject *)self, value, self->x_attr, name, NULL);
 }
 


### PR DESCRIPTION
Fixes error when "value" function is called on Windows Python 3.12 with an attribute that doesn't exist

![image](https://github.com/user-attachments/assets/54789c48-1d9f-434d-bc01-0d77350b360f)