### PR TITLE
Version docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,14 +22,14 @@
 * Windpower module example (#148)
 * Battery functions for reopt sizing (#149)
 
-## Version 4.1.0, Feb 24, 2023 - SAM 2022.11.21, Revision 2, SSC Version 279
+## Version 4.1.0, Feb 24, 2023 - SAM 2022.11.21, Revision 1, SSC Version 279
 * [SAM Release updates for Version 2022.11.21 Revision 2](https://nrel.github.io/SAM/doc/releasenotes.html)
 * Updated Documentation for INOUT variables (#141)
 * Added tolerance for Battery sizing tool (#140)
 * Add Python 3.11 support
 
-## Version 4.0.0, Dec 10, 2022 - SAM 2022.11.21, Revision 1, SSC Version 278
-* [SAM Release updates for Version 2022.11.21 Revision 1](https://nrel.github.io/SAM/doc/releasenotes.html)
+## Version 4.0.0, Dec 10, 2022 - SAM 2022.11.21, SSC Version 278
+* [SAM Release updates for Version 2022.11.21](https://nrel.github.io/SAM/doc/releasenotes.html)
 * Added LoadTools, URDBv8 support and utility rate fixes (#126, 128)
 * License update (#127)
 * PySSC modifications for arrays (#125)

--- a/docs/version_changes/3.0.0.rst
+++ b/docs/version_changes/3.0.0.rst
@@ -3,6 +3,8 @@
 Version 3.0.0
 ===============================================
 
+Version 3.0.0, released Dec 23, 2021, corresponds to SAM 2021.12.02, SSC 267.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/3.0.1.rst
+++ b/docs/version_changes/3.0.1.rst
@@ -3,6 +3,8 @@
 Version 3.0.1
 ===============================================
 
+Version 3.0.1, released Mar 4, 2022, corresponds to SAM 2021.12.02, Revision 1, SSC 268.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/3.0.2.rst
+++ b/docs/version_changes/3.0.2.rst
@@ -3,6 +3,8 @@
 Version 3.0.2
 ===============================================
 
+Version 3.0.2, released Sep 27, 2022, corresponds to SAM 2021.12.02, Revision 2, SSC 274.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/4.0.0.rst
+++ b/docs/version_changes/4.0.0.rst
@@ -3,6 +3,8 @@
 Version 4.0.0
 ===============================================
 
+Version 4.0.0, released Dec 10, 2022, corresponds to SAM 2022.11.21, SSC 278.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/4.1.0.rst
+++ b/docs/version_changes/4.1.0.rst
@@ -3,6 +3,8 @@
 Version 4.1.0
 ===============================================
 
+Version 4.1.0, released Feb 24, 2023, corresponds to SAM 2022.11.21, Revision 1, SSC 279.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/4.2.0.rst
+++ b/docs/version_changes/4.2.0.rst
@@ -3,6 +3,8 @@
 Version 4.2.0
 ===============================================
 
+Version 4.2.0, released June 30, 2023, corresponds to SAM 2022.11.21, Revision 3, SSC 280.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/5.0.0.rst
+++ b/docs/version_changes/5.0.0.rst
@@ -3,6 +3,8 @@
 Version 5.0.0
 ===============================================
 
+Version 5.0.0, released Dec 13, 2023, corresponds to SAM 2023.12.17, SSC 288.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/5.1.0.rst
+++ b/docs/version_changes/5.1.0.rst
@@ -3,6 +3,8 @@
 Version 5.1.0
 ===============================================
 
+Version 5.1.0, released Mar 13, 2024, corresponds to SAM 2023.12.17 Revision 1, SSC 290.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/version_changes/6.0.0.rst
+++ b/docs/version_changes/6.0.0.rst
@@ -3,6 +3,8 @@
 Version 6.0.0
 ===============================================
 
+Version 6.0.0, released Dec 12, 2024, corresponds to SAM 2024.12.12, SSC 298.
+
 This page compares the PySAM Modules' input variables and the defaults for these input variables 
 between the current release and the last release.
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -5,10 +5,8 @@ For a list of PySAM versions and their equivalent SAM and SSC versions, see http
 
 The list below tracks changes in variables between consecutive PySAM versions.
 
-For a list of 
-
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     version_changes/6.0.0.rst
     version_changes/5.1.0.rst


### PR DESCRIPTION
Thanks @cpaulgilman and @janinefreeman for the suggestions

- [x] Add SAM revision number to version information at https://github.com/NREL/pysam/releases,  e.g., "Version 5.1.0, March 13, 2024 - SAM 2023.12.17 Revision 1 SSC 290".

- [x] Fix typo "For a list of" in https://nrel-pysam.readthedocs.io/en/main/versions.html.

- [x] Show complete version information, e.g., "PySAM 5.1.0, SAM 2023.12.17 Revision 1, SSC 290" on PySAM Versions page at https://nrel-pysam.readthedocs.io/en/main/versions.html. (Also consider adding release date?)

- [x] Make it easier to see the list of version numbers https://nrel-pysam.readthedocs.io/en/main/versions.html  