### PR TITLE
Fix memory leak in table setters

### DIFF
--- a/csrc/PySAM_utils.h
+++ b/csrc/PySAM_utils.h
@@ -743,10 +743,10 @@ static int PySAM_table_setter(PyObject *value, SAM_set_table_t func, void *data_
     SAM_error error = new_error();
     (*func)(data_ptr, table, &error);
 
-    if (PySAM_has_error(error)){
-        SAM_table_destruct(table, NULL);
+    SAM_table_destruct(table, NULL);
+
+    if (PySAM_has_error(error))
         return -5;
-    }
 
     return 0;
 }
@@ -853,6 +853,8 @@ static int PySAM_assign_from_dict(void *data_ptr, PyObject *dict, const char *te
 
             error = new_error();
             func(data_ptr, table, &error);
+            // func copies the table into the module's data, so the intermediate must be freed
+            SAM_table_destruct(table, NULL);
             if (PySAM_has_error(error)) goto fail;
 
         }

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -1,0 +1,59 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+# The measurement loop runs in a subprocess: ru_maxrss is the process-lifetime PEAK RSS,
+# so measuring in the pytest process would be masked by whichever heavyweight tests ran
+# first. A fresh process gives a clean high-water mark regardless of suite order.
+_LEAK_LOOP = """
+import gc, json, resource, sys
+import PySAM.Pvwattsv8 as pv
+
+def max_rss_mb():
+    # ru_maxrss is bytes on macOS, kilobytes on Linux
+    divisor = 1e6 if sys.platform == "darwin" else 1e3
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / divisor
+
+hourly = [0.0] * 8760
+data = {
+    "lat": 33.45, "lon": -111.98, "tz": -7.0, "elev": 358.0,
+    **{k: hourly for k in ("year", "month", "day", "hour", "minute",
+                           "dn", "df", "gh", "wspd", "tdry")},
+}
+
+# Warm up allocator high-water mark before measuring
+for _ in range(5):
+    m = pv.new()
+    m.SolarResource.solar_resource_data = data
+gc.collect()
+before = max_rss_mb()
+
+for _ in range(100):
+    m = pv.new()
+    m.SolarResource.solar_resource_data = data
+gc.collect()
+
+print(json.dumps({"growth_mb": max_rss_mb() - before}))
+"""
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="resource module is POSIX-only")
+def test_table_setter_does_not_leak():
+    """Assigning a dict to a table variable must not leak the converted table.
+
+    Regression test for PySAM_table_setter leaking the intermediate SAM_table
+    on the success path: ~0.7MB of weather data leaked per solar_resource_data
+    assignment, which OOMs long-running services that create a model per request.
+    """
+    # -I (isolated mode) keeps the repo-root PySAM/ data dir off sys.path so the
+    # installed package is imported regardless of the pytest working directory.
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", _LEAK_LOOP], capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"leak-loop subprocess failed: {result.stderr}"
+    growth = json.loads(result.stdout.strip().splitlines()[-1])["growth_mb"]
+
+    # The unpatched leak grows peak RSS by ~70MB here; allow generous allocator noise
+    assert growth < 20, f"peak RSS grew {growth:.1f} MB over 100 table assignments"


### PR DESCRIPTION
## Problem

`PySAM_table_setter` converts the incoming Python dict to a `SAM_table` and passes it to the generated `*_tset` function, which copies the table into the module's data. The intermediate table is only destructed on the error path, so every successful dict assignment to a table variable leaks the full converted table.

For `Pvwattsv8.SolarResource.solar_resource_data` with an 8760-row weather file this is ~1.2MB leaked per assignment. Long-running services that build a model per request (e.g. a REST API wrapping PVWatts) leak until OOM. The leak is unreachable from Python.

`PySAM_assign_from_dict` (the `Model.assign()` path) has the same leak on both its success and error paths.

## Evidence

Repeat-loop RSS measurement (macOS arm64, Python 3.13, PySAM 7.1.0), assigning the same prebuilt dict to fresh `Pvwattsv8` models, GC forced, live Python object counts flat:

| Operation ×50 | RSS slope (before) | RSS slope (after fix) |
|---|---|---|
| `m.SolarResource.solar_resource_data = d` | +1.18 MB/iter, linear | +0.001 MB/iter |
| `m.assign({"SolarResource": {"solar_resource_data": d}})` | +1.18 MB/iter | +0.001 MB/iter |
| `pvwatts.new()` alone | flat | flat |

That the `*_tset` functions copy (rather than take ownership) is confirmed by the nested-table branch of `PySAM_dict_to_table` itself, which already destructs its intermediate right after a successful `SAM_table_set_table`.

## Verification

- `ac_annual` and all exported outputs bit-identical before/after the fix.
- New regression test `tests/test_memory_leak.py` (peak-RSS bound over 100 assignments, POSIX-only). It runs its measurement loop in a `python -I` subprocess so the peak-RSS reading is immune to test ordering and to the repo-root `PySAM/` dir shadowing the installed package. Fails on stock wheels, passes on patched builds.
- Verified on both CI platforms by replicating the workflow steps (published wheel + version-matched SAM checkout + `pytest tests/test_pysam_all.py`):
  - macOS arm64 (Python 3.13): 15/15 functional tests pass stock and patched; leak test fails stock (+82.7MB over 100 assignments), passes patched.
  - Linux aarch64, `python:3.13` container (manylinux2014 wheel): 15/15 functional tests     pass stock and patched; leak test fails stock (+62.4MB), passes patched.
- The leak reproduces in the latest published wheel (`nrel-pysam==7.1.1.post1`) on both platforms; it is not specific to an OS or an older release.

## Additional notes
`test_pkg.yml` installs the published wheel rather than building from source, so the new regression test will fail on the macOS jobs until a wheel containing this fix is published. It passes against any wheel built from a patched source tree.